### PR TITLE
Fix dark mode card and adjust scaling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -54,27 +54,25 @@ html, body {
    Enhanced Mobile‑Optimised Global Zoom Implementation
    ----------------------------------------------------------------- */
 html {
-  transform: scale(0.75);
+  zoom: 0.75;              /* preserve overall size without blurry transform */
   transform-origin: 0 0;
-  width: 133.33%;
-  height: 133.33%;
   overflow-x: hidden;
 }
 
 @media (max-width: 1024px) {
-  html { transform: scale(0.7);  width: 142.86%; height: 142.86%; }
+  html { zoom: 0.7; }
 }
-@media (max-width: 768px)  {
-  html { transform: scale(0.6);  width: 166.67%; height: 166.67%; }
+@media (max-width: 768px) {
+  html { zoom: 0.6; }
 }
-@media (max-width: 640px)  {
-  html { transform: scale(0.55); width: 181.82%; height: 181.82%; }
+@media (max-width: 640px) {
+  html { zoom: 0.55; }
 }
-@media (max-width: 480px)  {
-  html { transform: scale(0.5);  width: 200%;    height: 200%;    }
+@media (max-width: 480px) {
+  html { zoom: 0.5; }
 }
-@media (max-width: 360px)  {
-  html { transform: scale(0.45); width: 222.22%; height: 222.22%; }
+@media (max-width: 360px) {
+  html { zoom: 0.45; }
 }
 
 /* Responsive typography tweaks after global scaling */

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -227,7 +227,7 @@ function EnhancedTableView({
                 `}
               >
                 {/* Card */}
-                <div className="relative p-8 rounded-3xl border border-gray-200 dark:[#31313c] backdrop-blur-sm shadow-2xl hover:shadow-3xl transition-all">
+                <div className="relative p-8 rounded-3xl border border-gray-200 dark:bg-[#31313c] backdrop-blur-sm shadow-2xl hover:shadow-3xl transition-all">
                   {/* Rank badge */}
                   <div className={`${getRankBadge(i + 1)} absolute -top-4 -left-4 h-16 w-16 rounded-2xl flex items-center justify-center shadow-2xl transform -rotate-12 group-hover:rotate-0 transition-transform`}>
                     <span className="text-white text-2xl font-black">{i + 1}</span>


### PR DESCRIPTION
## Summary
- keep mobile zoom but switch from transform scale to `zoom`
- fix leaderboard card's dark mode background class

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: no test specified)*
- `npm test` in `backend/` *(fails: prints error message)*
