### PR TITLE
Add color scheme meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,12 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/amelogo.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover" />
-    <title>AggieTracker</title>
+      <meta charset="UTF-8" />
+      <link rel="icon" type="image/svg+xml" href="/amelogo.png" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover" />
+      <meta name="color-scheme" content="light dark" />
+      <meta name="supported-color-schemes" content="light dark" />
+      <title>AggieTracker</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- support both light and dark color schemes in the HTML entry

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866b2adefbc8320a795b6bdd36c5512